### PR TITLE
Fixed "lime setup linux" on Ubuntu 13.10 and later

### DIFF
--- a/tools/utils/PlatformSetup.hx
+++ b/tools/utils/PlatformSetup.hx
@@ -1761,7 +1761,7 @@ class PlatformSetup {
 			var lsbId = ProcessHelper.runProcess ("", "lsb_release", ["-si"], true, true, true);
 			var lsbRelease = ProcessHelper.runProcess ("", "lsb_release", ["-sr"], true, true, true);
 			var arch = ProcessHelper.runProcess ("", "uname", ["-m"], true, true, true);
-			var isSaucy = lsbId == "Ubuntu\n" &&  lsbRelease == "13.10\n" && arch == "x86_64\n";
+			var isSaucy = lsbId == "Ubuntu\n" &&  lsbRelease >= "13.10\n" && arch == "x86_64\n";
 			
 			var packages = isSaucy ? linuxUbuntuSaucyPackages : linuxAptPackages;
 			


### PR DESCRIPTION
Currently, this line only checks if the current Ubuntu version is 13.10. More versions of Ubuntu have been released since then.
The reason this line was included was because versions of Ubuntu at or after 13.10 no longer have the package `ia32-libs-multiarch`.
When attempting to run "haxelib run lime setup linux" on Ubuntu versions after 13.10, e.g. Ubuntu 14.04, Lime crashes since there is no `ia32-libs-multiarch` package available.
The issue with this line of code is that it only checks for Ubuntu 13.10, and not any versions after this. 

Fortunately, Haxe supports testing strings via comparison operators.
By replacing the `==` operator with `>=`, this line now instead checks for versions of Ubuntu at or after 13.10 Saucy Salamander.
This works on Ubuntu 14.04.1, and should work on other versions too. Versions of Ubuntu Before 13.10 should still stay the same; they will still install the `ia32-libs-multiarch` package.